### PR TITLE
Update NuGet packages across projects

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,9 +6,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.4" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,8 +6,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.7" />
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
     </ItemGroup>
 

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.6" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.7" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated various NuGet packages in `OperationResults.Sample.csproj` and `OperationResults.Sample.DataAccessLayer.csproj`. Specifically, upgraded `Microsoft.EntityFrameworkCore.InMemory` and `TinyHelpers.AspNetCore` in `OperationResults.Sample.csproj`, and `Microsoft.EntityFrameworkCore` in `OperationResults.Sample.DataAccessLayer.csproj` to their newer versions. This includes a consistent update of `Microsoft.EntityFrameworkCore.InMemory` and `Microsoft.AspNetCore.OpenApi` from `8.0.6` to `8.0.7` across the mentioned projects.