### PR TITLE
Update package versions and attributes in project files

### DIFF
--- a/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
+++ b/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.26" />
+        <PackageReference Include="OperationResultTools" Version="1.0.29" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
+++ b/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.26" />
+        <PackageReference Include="OperationResultTools" Version="1.0.29" />
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/OperationResultsTests/OperationResultsTests.csproj
+++ b/tests/OperationResultsTests/OperationResultsTests.csproj
@@ -10,10 +10,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated `OperationResults.AspNetCore.Http.csproj` and `OperationResults.AspNetCore.csproj` to change `OperationResultTools` package version from `1.0.26` to `1.0.29`.

In `OperationResultsTests.csproj`:
- Updated `coverlet.collector` from `6.0.0` to `6.0.2` and added `PrivateAssets` and `IncludeAssets` attributes.
- Updated `Microsoft.NET.Test.Sdk` from `17.8.0` to `17.11.1`.
- Updated `xunit` from `2.5.3` to `2.9.2`.
- Updated `xunit.runner.visualstudio` from `2.5.3` to `2.8.2` and added `PrivateAssets` and `IncludeAssets` attributes.