### PR TITLE
Update .NET to 9.x, CodeQL to v3, and super-linter to v7.2.0

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
     - cron: '0 0 1,15 * *'
     
 env:
-  NET_VERSION: '7.x'
+  NET_VERSION: '9.x'
     
 jobs:
   analyze:
@@ -41,10 +41,10 @@ jobs:
       with:
         dotnet-version: ${{ env.NET_VERSION }}
         dotnet-quality: 'ga'
-        
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -57,7 +57,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     # ?? Command-line programs to run using the OS shell.
     # ?? See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -70,4 +70,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -40,7 +40,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: super-linter/super-linter@v7.2.0
         env:
           LINTER_RULES_PATH: '.'
           EDITORCONFIG_FILE_NAME: '.editorconfig'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/OperationResults 
   PROJECT_FILE: OperationResults.csproj
   RELEASE_NAME: OperationResultTools

--- a/.github/workflows/publish_aspnetcore.yml
+++ b/.github/workflows/publish_aspnetcore.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/OperationResults.AspNetCore 
   PROJECT_FILE: OperationResults.AspNetCore.csproj
   TAG_NAME: aspnetcore

--- a/.github/workflows/publish_minimalapi.yml
+++ b/.github/workflows/publish_minimalapi.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  NET_VERSION: '8.x'
+  NET_VERSION: '9.x'
   PROJECT_NAME: src/OperationResults.AspNetCore.Http
   PROJECT_FILE: OperationResults.AspNetCore.Http.csproj
   TAG_NAME: minimalapi

--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -1,14 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="3.1.19" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.15" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.10" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/OperationResults.Sample.BusinessLayer/OperationResults.Sample.BusinessLayer.csproj
+++ b/samples/OperationResults.Sample.BusinessLayer/OperationResults.Sample.BusinessLayer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
     </ItemGroup>
 </Project>

--- a/samples/OperationResults.Sample.Shared/OperationResults.Sample.Shared.csproj
+++ b/samples/OperationResults.Sample.Shared/OperationResults.Sample.Shared.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.6.146"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/src/OperationResults/OperationResults.csproj
+++ b/src/OperationResults/OperationResults.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -9,7 +9,7 @@
         <Company>Marco Minerva</Company>
         <Product>OperationResults</Product>
         <Title>OperationResults</Title>
-        <Description>A lightweight library to totally decouple operation results and actual application responses..</Description>
+        <Description>A lightweight library to totally decouple operation results and actual application responses.</Description>
         <PackageId>OperationResultTools</PackageId>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <PackageProjectUrl>https://github.com/marcominerva/OperationResults</PackageProjectUrl>

--- a/tests/OperationResultsTests/OperationResultsTests.csproj
+++ b/tests/OperationResultsTests/OperationResultsTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request includes several updates to the project dependencies and workflows to support .NET 9 and newer versions of various packages. The most important changes include updating the .NET version, upgrading GitHub Actions workflows, and updating package references in project files.

### Updates to .NET Version:

* Updated `NET_VERSION` to '9.x' in `.github/workflows/codeql.yml`, `.github/workflows/publish.yml`, `.github/workflows/publish_aspnetcore.yml`, and `.github/workflows/publish_minimalapi.yml` [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L15-R15) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L10-R10) [[3]](diffhunk://#diff-031af86fdd0a1a19e19ed80fe21e9130b315ce45828f479c77bf0e34cd4b9cb6L10-R10) [[4]](diffhunk://#diff-232fc618878ebe356d35956422721bc17730d2f701073b787f1fc92cb0c37b06L10-R10).

### Upgrades to GitHub Actions Workflows:

* Updated `github/codeql-action` to version `v3` in `.github/workflows/codeql.yml` [[1]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L47-R47) [[2]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L60-R60) [[3]](diffhunk://#diff-12783128521e452af0cfac94b99b8d250413c516ec71fe6d97dbea666ff7ba27L73-R73).
* Updated `super-linter` to version `v7.2.0` in `.github/workflows/linter.yml`.

### Updates to Project and Package References:

* Updated target framework to `net9.0` in various project files including `samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj`, `samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj`, `samples/OperationResults.Sample.BusinessLayer/OperationResults.Sample.BusinessLayer.csproj`, `samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj`, `samples/OperationResults.Sample.Shared/OperationResults.Sample.Shared.csproj`, `src/OperationResults/OperationResults.csproj`, and `tests/OperationResultsTests/OperationResultsTests.csproj` [[1]](diffhunk://#diff-32ceeefd7d2fcf781f299d71d54a84e664990506568320fae6eaeee7d6ef0c79L4-R12) [[2]](diffhunk://#diff-b3613d7969eae13447d0898798a02cc416cf9b4d900550f18fd29f1a454e4838L4-R11) [[3]](diffhunk://#diff-cac0a377780b3cfbb813c87234474b68d436fce00bfe67fff0b234ee7cd5d902L4-R4) [[4]](diffhunk://#diff-5038fcc4244b9fa3e97997508e604a0450deb06849bb97f85205b8bb4734baabL4-R9) [[5]](diffhunk://#diff-d62e356fe68bea74269d829bb7d2fc6d7ab1d943f1a29734241ff1646854be21L4-R4) [[6]](diffhunk://#diff-5257046f46f76dfe2d7d4cec2620a9669050804987b352e1d6faa3529b94a8bfL4-R12) [[7]](diffhunk://#diff-2a846f1ac131046bff0b80dfa718fb514364485155417d6c90a10759a026b30eL4-R4).
* Updated several package references to their latest versions, including `Microsoft.EntityFrameworkCore.InMemory`, `Swashbuckle.AspNetCore`, `TinyHelpers.AspNetCore`, `coverlet.collector`, `Microsoft.NET.Test.Sdk`, and `xunit` in various project files [[1]](diffhunk://#diff-32ceeefd7d2fcf781f299d71d54a84e664990506568320fae6eaeee7d6ef0c79L4-R12) [[2]](diffhunk://#diff-b3613d7969eae13447d0898798a02cc416cf9b4d900550f18fd29f1a454e4838L4-R11) [[3]](diffhunk://#diff-2a846f1ac131046bff0b80dfa718fb514364485155417d6c90a10759a026b30eL13-R19).

### Additional Changes:

* Updated `Nerdbank.GitVersioning` to version `3.7.115` in `src/Directory.Build.props`.
* Fixed a typo in the description of `OperationResults.csproj`.