### PR TITLE
Update NuGet packages and modify Swagger response handling

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.15" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.8" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.14" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/Controllers/OperationResults.Sample/Program.cs
+++ b/samples/Controllers/OperationResults.Sample/Program.cs
@@ -48,7 +48,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(options =>
 {
     options.AddAcceptLanguageHeader();
-    options.AddDefaultResponse();
+    options.AddDefaultProblemDetailsResponse();
 });
 
 var app = builder.Build();

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.2.0" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.15" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.14" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
     </ItemGroup>
 </Project>

--- a/tests/OperationResultsTests/OperationResultsTests.csproj
+++ b/tests/OperationResultsTests/OperationResultsTests.csproj
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated `OperationResults.Sample`, `OperationResults.Sample.DataAccessLayer`, and `OperationResultsTests` project files to use the latest versions of several NuGet packages, including `Microsoft.EntityFrameworkCore`, `Swashbuckle.AspNetCore`, and others. Changed the Swagger configuration in `Program.cs` to replace `AddDefaultResponse()` with `AddDefaultProblemDetailsResponse()`.