### PR TITLE
Update package versions for Swashbuckle and TinyHelpers

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -7,9 +7,9 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
         <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.14" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.16" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -8,9 +8,9 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="7.3.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
         <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.21" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.14" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.16" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
- Upgraded `Swashbuckle.AspNetCore` from `7.3.1` to `8.0.0`.
- Upgraded `TinyHelpers.AspNetCore.Swashbuckle` from `4.0.14` to `4.0.16`.