### PR TITLE
Update package references to latest versions

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.23" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.18" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.19" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.4" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.0" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.23" />
-        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.18" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.1" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.26" />
+        <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.19" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
     </ItemGroup>
 </Project>

--- a/tests/OperationResultsTests/OperationResultsTests.csproj
+++ b/tests/OperationResultsTests/OperationResultsTests.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated various package references across project files:
- `OperationResults.Sample.csproj`: Upgraded `Microsoft.EntityFrameworkCore.InMemory`, `Swashbuckle.AspNetCore`, `TinyHelpers.AspNetCore`, and `TinyHelpers.AspNetCore.Swashbuckle` to their latest versions.
- Updated `Microsoft.AspNetCore.OpenApi` to version 9.0.5.
- `OperationResults.Sample.DataAccessLayer.csproj`: Upgraded `Microsoft.EntityFrameworkCore` to version 9.0.5.
- `OperationResultsTests.csproj`: Updated `xunit.runner.visualstudio` to version 3.1.0.