### PR TITLE
Update Swashbuckle.AspNetCore to version 9.0.1

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
         <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.27" />
         <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.22" />
     </ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -8,7 +8,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.6" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
         <PackageReference Include="TinyHelpers.AspNetCore" Version="4.0.27" />
         <PackageReference Include="TinyHelpers.AspNetCore.Swashbuckle" Version="4.0.22" />
     </ItemGroup>


### PR DESCRIPTION
Updated the `Swashbuckle.AspNetCore` package version from `8.1.4` to `9.0.1` in the `OperationResults.Sample.csproj` file.