### PR TITLE
Update package references to latest versions

### DIFF
--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.8" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
         <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.4" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.7" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.4" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.7" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated package references in `OperationResults.Sample.csproj` and `OperationResults.Sample.DataAccessLayer.csproj`.
- Upgraded `Microsoft.AspNetCore.OpenApi` and `Microsoft.EntityFrameworkCore.InMemory` from `9.0.8` to `9.0.9`.
- Upgraded `TinyHelpers.AspNetCore` from `4.1.4` to `4.1.6`.
- Updated `Microsoft.EntityFrameworkCore` from `9.0.7` to `9.0.9`.
- Updated `Swashbuckle.AspNetCore` from `9.0.3` to `9.0.4`.