### PR TITLE
Update OperationResultTools to version 1.0.32

### DIFF
--- a/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
+++ b/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.30" />
+        <PackageReference Include="OperationResultTools" Version="1.0.32" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
+++ b/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.30" />
+        <PackageReference Include="OperationResultTools" Version="1.0.32" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Updated the `OperationResultTools` package reference in both `OperationResults.AspNetCore.Http.csproj` and
`OperationResults.AspNetCore.csproj` from version 1.0.30 to version 1.0.32 to ensure the project uses the latest available version of the dependency.