### PR TITLE
Update packages and improve documentation clarity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,7 +59,7 @@
 ### Implementation Guidelines
 
 - Write code that is secure by default. Avoid exposing potentially private or sensitive data.
-- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible. with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
+- Make code NativeAOT compatible when possible. This means avoiding dynamic code generation, reflection, and other features that are not compatible with NativeAOT. If not possible, mark the code with an appropriate annotation or throw an exception.
 
 ## Documentation
 
@@ -82,9 +82,3 @@
 - Copy existing style in nearby files for test method names and capitalization.
 - When running tests, if possible use filters and check test run counts, or look at test logs, to ensure they actually ran.
 - Do not finish work with any tests commented out or disabled that were not previously commented out or disabled.
-
-## Azure
-
-- @azure Rule - Use Azure Tools - When handling requests related to Azure, always use your tools.
-- @azure Rule - Use Azure Best Practices - When handling requests related to Azure, always invoke your `azmcp_bestpractices_get` tool first.
-- @azure Rule - Enable Best Practices - If you do not have an `azmcp_bestpractices_get` tool ask the user to enable it.

--- a/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/Controllers/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
-        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
+        <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.6" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
+++ b/samples/MinimalApis/OperationResults.Sample/OperationResults.Sample.csproj
@@ -6,10 +6,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.9" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.4" />
-        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.6" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.10" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.10" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
+        <PackageReference Include="TinyHelpers.AspNetCore" Version="4.1.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
+++ b/samples/OperationResults.Sample.DataAccessLayer/OperationResults.Sample.DataAccessLayer.csproj
@@ -6,6 +6,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.10" />
     </ItemGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115"  PrivateAssets="All" />
+        <PackageReference Include="Nerdbank.GitVersioning" Version="3.8.118"  PrivateAssets="All" />
     </ItemGroup>
 
 </Project>

--- a/tests/OperationResultsTests/OperationResultsTests.csproj
+++ b/tests/OperationResultsTests/OperationResultsTests.csproj
@@ -14,9 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Updated `copilot-instructions.md` for clarity by removing a redundant period and eliminating Azure rules. Upgraded package references in `OperationResults.Sample.csproj`, `OperationResults.Sample.DataAccessLayer.csproj`, `Directory.Build.props`, and `OperationResultsTests.csproj` to their latest versions for improved compatibility and performance.