### PR TITLE
Update OperationResultTools to v1.0.37 in csproj files

### DIFF
--- a/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
+++ b/src/OperationResults.AspNetCore.Http/OperationResults.AspNetCore.Http.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.33" />
+        <PackageReference Include="OperationResultTools" Version="1.0.37" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
+++ b/src/OperationResults.AspNetCore/OperationResults.AspNetCore.csproj
@@ -25,7 +25,7 @@
     </ItemGroup>
 
     <ItemGroup>        
-        <PackageReference Include="OperationResultTools" Version="1.0.33" />
+        <PackageReference Include="OperationResultTools" Version="1.0.37" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Upgraded OperationResultTools package reference from 1.0.33 to 1.0.37 in OperationResults.AspNetCore.Http.csproj and OperationResults.AspNetCore.csproj. No other changes were made.